### PR TITLE
docs: add CODE_OF_CONDUCT link to root

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,2 @@
-### HTTP/1.1 302 Found
-- Location: https://coder.com/docs/coder-oss/latest/contributing/CODE_OF_CONDUCT
+## Coder CODE_OF_CONDUCT
+- Location: [https://coder.com/docs/coder-oss/latest/contributing/CODE_OF_CONDUCT](https://coder.com/docs/contributing/CODE_OF_CONDUCT)


### PR DESCRIPTION
CODE_OF_CONDUCT is built as part of the documentation. This adds a link from the repo/root