### PR TITLE
fix: readme hiring link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,4 +8,4 @@ curl coder.com
 
 ## Hiring
 
-Apply [here](https://cdr.co/github-apply) if you're interested in joining our team.
+Apply [here](https://jobs.ashbyhq.com/coder?utm_source=gJyD4K16r8) if you're interested in joining our team.


### PR DESCRIPTION
Fixed hiring link. Unable to find/update the original shortlink so I'm replacing it with a link provided by our recruiting team.